### PR TITLE
fix require vs import of ES module error

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -137,6 +137,7 @@ export default {
   // Build Configuration (https://go.nuxtjs.dev/config-build)
   build: {
     extractCSS: process.env.NODE_ENV === 'production',
+    standalone: true,
   },
 
   // Watch asset files (prevent manual reload when adding new assets)


### PR DESCRIPTION
this fixed the following `require()` error:

![image](https://user-images.githubusercontent.com/902958/214273695-3c17ccc8-1645-4f49-88b2-d29758ff32fb.png)

this must have been introduced during a dependency update to `vue-server-renderer`.

see for context about this fix: https://github.com/nuxt/nuxt/issues/9223#issuecomment-840747064.

running 
```
npm run dev
```
should now work as usual
