### PR TITLE
Add data dashboard tab to moz dataset page #466

### DIFF
--- a/components/dataset/TabDashboard.vue
+++ b/components/dataset/TabDashboard.vue
@@ -1,0 +1,85 @@
+<template>
+  <v-tab-item key="dashboard" value="dashboard">
+    <section class="mt-0">
+      <!-- Stats -->
+      <v-row
+        v-if="dataset"
+        :style="{ fontSize: '0.8em' }"
+        class="justify-start text-uppercase grey--text darken-4 title-font pb-2 mb-3 flex-wrap"
+      >
+        <v-col
+          v-for="(stat, index) of stats"
+          :key="index"
+          :style="{ borderBottom: '1px solid #eee' }"
+          class="flex-shrink-0 text-no-wrap"
+        >
+          <v-icon size="17" class="pb-0 mr-2">{{ stat.icon }}</v-icon>
+          <strong> {{ stat.text }} </strong>
+        </v-col>
+      </v-row>
+
+      <v-alert type="warning"
+        >For now this dashboard tab contains the content of the Overview tab as
+        placeholder.</v-alert
+      >
+
+      <!-- Description -->
+      <nuxt-content :document="page" />
+
+      <!-- Chiplist -->
+      <v-row class="justify-center mt-5">
+        <v-col class="limit-width px-3 py-3 mb-2">
+          <ArticleRelations :projects="projects" />
+        </v-col>
+      </v-row>
+      <v-row class="justify-center">
+        <v-col class="limit-width px-3 py-3 mb-2">
+          <ArticleRelations :blogs="blogs" />
+        </v-col>
+      </v-row>
+    </section>
+  </v-tab-item>
+</template>
+<script>
+import ArticleRelations from '../ArticleRelations'
+import icons from '~/config/icons'
+import { classColors } from '~/config/theme'
+
+export default {
+  components: { ArticleRelations },
+  props: {
+    projects: { type: Array, required: false, default: () => [] },
+    blogs: { type: Array, required: false, default: () => [] },
+    page: { type: Object, required: false, default: null },
+    dataset: { type: Object, required: true, default: null },
+  },
+  data() {
+    return {
+      icons,
+      classColors,
+      stats: [
+        {
+          icon: 'mdi-domain',
+          text: this.dataset?.publisher?.name || this.dataset?.creator?.name,
+        },
+        {
+          icon: 'mdi-license',
+          text: this.dataset?.license?.name,
+        },
+        this.dataset?.size
+          ? {
+              icon: 'mdi-file-document-multiple',
+              text: this.dataset?.size + ' ' + this.$t('records'),
+            }
+          : {},
+        this.dataset?.['sdo:temporalCoverage']
+          ? {
+              icon: 'mdi-calendar-range',
+              text: this.dataset['sdo:temporalCoverage'],
+            }
+          : {},
+      ],
+    }
+  },
+}
+</script>

--- a/components/dataset/TabOverview.vue
+++ b/components/dataset/TabOverview.vue
@@ -13,7 +13,7 @@
           :style="{ borderBottom: '1px solid #eee' }"
           class="flex-shrink-0 text-no-wrap"
         >
-          <v-icon size="17" class="pb-0 mr-2" v-text="stat.icon"> </v-icon>
+          <v-icon size="17" class="pb-0 mr-2">{{ stat.icon }}</v-icon>
           <strong> {{ stat.text }} </strong>
         </v-col>
       </v-row>

--- a/content/en/datasets/muziekopnamen-zendgemachtigden.md
+++ b/content/en/datasets/muziekopnamen-zendgemachtigden.md
@@ -5,6 +5,7 @@ subtitle: The audio collection 'Music recordings broadcasting agents' (MOZ) with
 color: ''
 image: '/uploads/NL-HaNA_2.24.01.05_0_923-3652-groot.jpg'
 tags: []
+showDashboard: true
 ---
 
 Original concert and studio recordings made by public broadcasters. Integral recordings across many genres.

--- a/pages/datasets/_slug.vue
+++ b/pages/datasets/_slug.vue
@@ -34,7 +34,9 @@
             />
             <!-- Metadata -->
             <TabMetadata v-if="dataset" :dataset="dataset" />
+            <!-- Dashboard -->
             <TabDashboard
+              v-if="datasetPage.showDashboard"
               :dataset="dataset"
               :page="datasetPage"
               :projects="projects"
@@ -136,7 +138,7 @@ export default {
     classColors,
     icon: icons.dataset,
     color: classColors.dataset,
-    submenu: ['overview', 'metadata', 'dashboard'],
+    submenu: ['overview', 'metadata'],
     activeSubmenu: null,
   }),
   head() {
@@ -145,15 +147,18 @@ export default {
       title,
     }
   },
-  // mounted() {
-  //   Set default submenu to hash
-  //   if (!this.$route.hash) {
-  //     window.history.replaceState(
-  //       null,
-  //       window.title,
-  //       this.$route.path + '#' + this.submenu[0]
-  //     )
-  //   }
-  // },
+  mounted() {
+    if (this.datasetPage.showDashboard) {
+      this.submenu.push('dashboard')
+    }
+    // Set default submenu to hash
+    // if (!this.$route.hash) {
+    //   window.history.replaceState(
+    //     null,
+    //     window.title,
+    //     this.$route.path + '#' + this.submenu[0]
+    //   )
+    // }
+  },
 }
 </script>

--- a/pages/datasets/_slug.vue
+++ b/pages/datasets/_slug.vue
@@ -34,6 +34,12 @@
             />
             <!-- Metadata -->
             <TabMetadata v-if="dataset" :dataset="dataset" />
+            <TabDashboard
+              :dataset="dataset"
+              :page="datasetPage"
+              :projects="projects"
+              :blogs="blogs"
+            />
           </v-tabs-items>
         </section>
       </v-col>
@@ -44,6 +50,7 @@
 <script>
 import TabOverview from '~/components/dataset/TabOverview'
 import TabMetadata from '~/components/dataset/TabMetadata'
+import TabDashboard from '~/components/dataset/TabDashboard'
 import ArticleHeader from '~/components/ArticleHeader'
 import { getLocalePath } from '~/util/contentFallback'
 import icons from '~/config/icons'
@@ -56,6 +63,7 @@ export default {
     ArticleHeader,
     TabMetadata,
     TabOverview,
+    TabDashboard,
   },
 
   async asyncData({ $content, app, params, error }) {
@@ -128,8 +136,7 @@ export default {
     classColors,
     icon: icons.dataset,
     color: classColors.dataset,
-
-    submenu: ['overview', 'metadata'],
+    submenu: ['overview', 'metadata', 'dashboard'],
     activeSubmenu: null,
   }),
   head() {


### PR DESCRIPTION
Visualising core stats of the MOZ collection in a separate dataset tab.

For now this adds a new dashboard tab to dataset pages, if `showDashboard` is set to `true` in a dataset content file's frontmatter.
 
Currently investigating ways to display visualisations within this tab. 