### PR TITLE
added created on date

### DIFF
--- a/.forestry/front_matter/templates/blog-post.yml
+++ b/.forestry/front_matter/templates/blog-post.yml
@@ -10,6 +10,10 @@ fields:
 - type: text
   name: subtitle
   label: Subtitle
+- type: date
+  name: createdOn
+  label: Date created
+  description: The date the blog post was created, in the format YYYY-MM-dd
 - type: file
   name: image
   label: Image

--- a/components/ArticlePage.vue
+++ b/components/ArticlePage.vue
@@ -25,7 +25,7 @@
 
       <v-divider class="my-5" />
 
-      <!-- Display selected article fiels if present -->
+      <!-- Display selected article fields if present -->
       <data-table
         :object="{
           ...(articleDefined.contacts && {
@@ -46,7 +46,11 @@
 
       <v-divider class="my-5" />
 
-      <p class="caption">
+      <p v-if="article.createdOn != null" class="caption">
+        {{ $t('created_on') }}: {{ formatDate(article.createdOn) }}
+      </p>
+
+      <p v-if="article.createdOn == null" class="caption">
         {{ $t('last_update') }}: {{ formatDate(article.updatedAt) }}
       </p>
 
@@ -83,7 +87,7 @@ export default {
         title: 'Empty article',
         subtitle: '',
         slug: '',
-        updatedAt: new Date(),
+        createdAt: new Date(),
         datasets: [],
         tags: [],
       }),

--- a/content/en/blogs/moz-dataset-blog.md
+++ b/content/en/blogs/moz-dataset-blog.md
@@ -4,6 +4,7 @@ subtitle: From Mozart to Metallica - a look at the rich variety of concerts reco
 image: datasets/moz.jpg
 tags: Metadata, Linked Open Data, Music
 lab: opendatalab
+createdOn: "2023-04-03"
 datasets: []
 ---
 Photo by Danny Howe on Unsplash

--- a/content/nl/blogs/moz-dataset-blog.md
+++ b/content/nl/blogs/moz-dataset-blog.md
@@ -4,6 +4,7 @@ subtitle: Van Mozart tot Metallica - een kijk in de rijke aanbod van concerten o
 image: datasets/moz.jpg
 tags: Metadata, Linked Open Data, Muziek
 lab: opendatalab
+createdOn: "2023-04-03"
 datasets: []
 ---
 Photo by Danny Howe on Unsplash

--- a/locales/en.json
+++ b/locales/en.json
@@ -27,6 +27,7 @@
   "about": "About",
   "about_description": "Who we are, what we do",
   "last_update": "Last update",
+  "created_on": "Created on",
   "read_more": "Read more",
   "metadata": "Metadata",
   "download_metadata": "JSON-LD",

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -17,6 +17,7 @@
   "about": "Over ons",
   "about_description": "Wie we zijn, what we doen",
   "last_update": "Laatste wijziging",
+  "created_on": "Gemaakt op",
   "read_more": "Lees meer",
   "explore_dataset": "Dataset verkennen"
 }


### PR DESCRIPTION
I've added a createdOn date, which can be set in the front matter. If it is present, it is shown at the bottom of the page. If it is not, then the date updated is shown instead.

Test plan:
- [ ] Check out this branch and check that the behaviour is as described (MOZ blogs have createdOn dates, the Welcome blog doesn't). 
- [ ] Are the changes to the frontmatter templates correct? I can't log in to forestry (is now TinaCMS!) to check
- [ ] Is this the desired behaviour, or do we want e.g. both created on and last updated to be shown if present?
- [ ] The change is currently only for blog posts, as this issue only related to the data story. Is that the way we want it, or do we want creation dates for other pages?